### PR TITLE
design: TextArea 구현

### DIFF
--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -3,11 +3,11 @@ import styled from "styled-components";
 import theme from "@/styles/theme";
 
 type TextAreaProps = {
-  value?: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   disabled?: boolean;
   placeholder?: string;
   errorText?: string;
-  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 };
 
 const TextArea = (props: TextAreaProps) => {

--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import styled from "styled-components";
+import theme from "@/styles/theme";
+
+type TextAreaProps = {
+  value?: string;
+  disabled?: boolean;
+  placeholder?: string;
+  errorText?: string;
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+};
+
+const TextArea = (props: TextAreaProps) => {
+  const { errorText, ...rest } = props;
+  return (
+    <TextAreaWrapper>
+      <StyledTextArea {...rest} $isError={!!errorText} />
+      {errorText && <ErrorText>{errorText}</ErrorText>}
+    </TextAreaWrapper>
+  );
+};
+
+export default TextArea;
+
+const StyledTextArea = styled.textarea<{ $isError?: boolean }>`
+  width: 335px;
+  height: 124px;
+  border-radius: 8px;
+  background-color: ${theme.extraWhite};
+  border: 1px solid
+    ${({ $isError }) =>
+      $isError ? `${theme.danger.d100}` : `${theme.gray.g20}`};
+  padding: 12px 16px;
+  color: ${theme.gray.g100};
+  &::placeholder {
+    color: ${theme.gray.g40};
+  }
+  &:focus {
+    border: 1px solid ${theme.primary.p100};
+  }
+  &:disabled {
+    border: 1px solid ${theme.gray.g20};
+    background-color: ${theme.background};
+  }
+`;
+
+const ErrorText = styled.div`
+  color: ${theme.danger.d100};
+  font-size: ${theme.caption12};
+`;
+
+const TextAreaWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -11,7 +11,7 @@ table, caption, tbody, tfoot, thead, tr, th, td,
 article, aside, canvas, details, embed, 
 figure, figcaption, footer, header, hgroup, 
 menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
+time, mark, audio, video, textarea {
 	margin: 0;
 	padding: 0;
 	border: 0;
@@ -41,4 +41,16 @@ q:before, q:after {
 table {
 	border-collapse: collapse;
 	border-spacing: 0;
+}
+
+textarea {
+    border: none;
+    overflow: auto;
+    outline: none;
+
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+
+    resize: none; /*remove the resize handle on the bottom right*/
 }


### PR DESCRIPTION
## 작업 내용 ⚒️

- TextArea를 작업했습니다.

## 리뷰어 참고 사항 🤔

- reset.css에 textarea 태그 스타일 리셋 코드를 추가했습니다.

## 스크린샷 📸

![image](https://github.com/user-attachments/assets/60d6a00f-35cf-4463-a8c3-14220adc8f1b)
